### PR TITLE
fix(macos_privileged_helper): 修正模块搜索路径的父级目录层级

### DIFF
--- a/modules/platform/macos_privileged_helper.py
+++ b/modules/platform/macos_privileged_helper.py
@@ -30,7 +30,9 @@ except ImportError:
     # 作为脚本运行时，没有包上下文，补充模块搜索路径
     import sys
 
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    project_root = Path(__file__).resolve().parents[2]
+    if str(project_root) not in sys.path:
+        sys.path.append(str(project_root))
     from modules.runtime.resource_manager import is_packaged
 
 JsonDict = dict[str, Any]


### PR DESCRIPTION
将路径解析从parent.parent改为parents[2]，确保正确获取项目根目录