### PR TITLE
fix(ci): avoid tauri resource path panic in rust gate

### DIFF
--- a/docs/test-pr.md
+++ b/docs/test-pr.md
@@ -1,0 +1,4 @@
+# Test PR for CI Gate
+
+This PR is only for validating branch protection and CI checks.
+It contains no product or runtime changes.

--- a/scripts/rs-check.mjs
+++ b/scripts/rs-check.mjs
@@ -16,6 +16,11 @@ const fmtArgs = mode === "gate" ? ["fmt", "--check"] : ["fmt"];
 
 if (mode === "gate") {
   delete env.PYO3_PYTHON;
+
+  const pyembedResourceDir = path.resolve("src-tauri", "pyembed", "python");
+  if (!fs.existsSync(pyembedResourceDir)) {
+    fs.mkdirSync(pyembedResourceDir, { recursive: true });
+  }
 } else {
   const pyembedPython =
     process.platform === "win32"


### PR DESCRIPTION
This draft PR fixes Rust gate startup panic by ensuring the src-tauri/pyembed/python resource directory exists in gate mode.\n\nIt also keeps the temporary test file for validating PR checks.