### PR TITLE
fix: 修复通过openai协议代理三方的Anthropic模型Trae运行报错: text content blocks must b…

### DIFF
--- a/python-src/modules/proxy/proxy_app.py
+++ b/python-src/modules/proxy/proxy_app.py
@@ -394,6 +394,26 @@ class ProxyApp:
                 log(f"请求中没有 stream 参数，设置为 {stream_value}")
                 request_data["stream"] = stream_value
 
+        messages = request_data.get("messages", [])
+        if isinstance(messages, list):
+            cleaned = False
+            for msg in messages:
+                if not isinstance(msg, dict):
+                    continue
+                content = msg.get("content")
+                if isinstance(content, str):
+                    if content == "":
+                        msg["content"] = " "
+                        cleaned = True
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            if block.get("text") == "":
+                                block["text"] = " "
+                                cleaned = True
+            if cleaned:
+                log("检测到空文本块/空内容，已自动将其修改为单个空格以防止目标API报错 (例如 Anthropic API)")
+
         auth_header = request.headers.get("Authorization")
         if not auth.verify(auth_header):
             log("聊天补全请求MTGA鉴权失败")


### PR DESCRIPTION
修复：messages: text content blocks must be non-empty。

这是 Anthropic API（或是像 OneAPI/NewAPI 这种转发给 Anthropic 的中间件）返回的 HTTP 400 校验错误。其原因是，当客户端发送的请求体中的 messages 数组包含空内容的文本块（例如 {"role": "user", "content": ""}，这在没有输入系统提示词时客户端经常会发送系统角色的空内容，或是纯粹发送了空的文本块 [{"type": "text", "text": ""}]）时，Anthropic 强制要求所有的文本块（text block）内容不能为空，否则就会返回该错误。

这里的修复处理是将`request_data`发送给上游`target_url`前，代码会遍历请求的`messages`数组，如果发现任何 content 是空字符串 ""，或是它的块内容是包含` {"type": "text", "text": ""}`，就会自动将其替换为一个空格 " "。

![img_v3_02vb_a6a9e156-0469-4d3c-91ca-cd6a9fdc33bg](https://github.com/user-attachments/assets/051884b4-22c1-403b-aaa1-f0b3fdd48c0f)