### PR TITLE
feat: 支持 API 429 (Too Many Requests) 自动故障转移与轮询

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,7 +65,7 @@
     "editor.defaultFormatter": "redhat.vscode-yaml",
     "editor.formatOnSave": true
   },
-  "python.languageServer": "Pylance",
+  "python.languageServer": "None",
   "rust-analyzer.cargo.extraEnv": {
     "PYO3_PYTHON": "${workspaceFolder}/src-tauri/pyembed/python/python.exe"
   }

--- a/app/components/panels/ConfigGroupPanel.vue
+++ b/app/components/panels/ConfigGroupPanel.vue
@@ -248,6 +248,10 @@ const handleSave = async () => {
     configGroups.value.push(payload);
     currentIndex.value = configGroups.value.length - 1;
   } else if (hasSelection.value) {
+    const currentGroup = configGroups.value[selectedIndex.value];
+    if (currentGroup?.id) {
+      payload.id = currentGroup.id;
+    }
     configGroups.value.splice(selectedIndex.value, 1, payload);
   }
 
@@ -449,7 +453,7 @@ const moveDown = async () => {
           <tbody v-if="configGroups.length">
             <tr
               v-for="(group, index) in configGroups"
-              :key="index"
+              :key="group.id || index"
               class="cursor-pointer transition-colors hover:bg-amber-100/30 group"
               :class="selectedIndex === index ? 'bg-amber-100/70' : ''"
               :style="{ height: 'var(--row-h)' }"

--- a/app/components/panels/SettingsPanel.vue
+++ b/app/components/panels/SettingsPanel.vue
@@ -123,6 +123,13 @@ const enable429Failover = computed({
   },
 });
 
+const failover429CooldownSeconds = computed({
+  get: () => store.failover429CooldownSeconds.value,
+  set: (value) => {
+    store.failover429CooldownSeconds.value = value;
+  },
+});
+
 const handleFailoverChange = async () => {
   const ok = await store.saveConfig();
   if (ok) {
@@ -168,6 +175,16 @@ const handleThemeSave = (value: ThemeConfig) => {
           @change="handleFailoverChange"
         />
         <span class="label-text text-slate-700">启用 API 智能调度（轮询 + 429 切换）</span>
+      </label>
+      <label class="label justify-start gap-3 p-0 pl-11">
+        <span class="label-text text-slate-700">429 冷却（秒）</span>
+        <input
+          v-model.number="failover429CooldownSeconds"
+          type="number"
+          min="1"
+          class="input input-sm w-24"
+          @change="handleFailoverChange"
+        />
       </label>
       <div class="text-xs text-slate-500 pl-11">
         开启后，请求会在配置组间轮询分发；当某个节点触发 429 (Too Many Requests) 时，

--- a/app/components/panels/SettingsPanel.vue
+++ b/app/components/panels/SettingsPanel.vue
@@ -116,6 +116,22 @@ const openThemeDialog = () => {
   themeDialogOpen.value = true;
 };
 
+const enable429Failover = computed({
+  get: () => store.enable429Failover.value,
+  set: (value) => {
+    store.enable429Failover.value = value;
+  },
+});
+
+const handleFailoverChange = async () => {
+  const ok = await store.saveConfig();
+  if (ok) {
+    store.appendLog(`API 智能调度已${enable429Failover.value ? "启用" : "禁用"}`);
+  } else {
+    store.appendLog("保存配置失败");
+  }
+};
+
 const handleThemeSave = (value: ThemeConfig) => {
   const normalized = sanitizeThemeConfig(value);
   copyThemeConfig(themeConfig, normalized);
@@ -139,6 +155,26 @@ const handleThemeSave = (value: ThemeConfig) => {
   </div>
 
   <div class="mt-4 space-y-4">
+    <div class="mtga-soft-panel space-y-3">
+      <div>
+        <div class="text-sm font-semibold text-slate-900">高级策略</div>
+        <div class="text-xs text-slate-500">API 调度与故障转移</div>
+      </div>
+      <label class="label cursor-pointer justify-start gap-3 p-0">
+        <input
+          v-model="enable429Failover"
+          type="checkbox"
+          class="toggle toggle-primary toggle-sm"
+          @change="handleFailoverChange"
+        />
+        <span class="label-text text-slate-700">启用 API 智能调度（轮询 + 429 切换）</span>
+      </label>
+      <div class="text-xs text-slate-500 pl-11">
+        开启后，请求会在配置组间轮询分发；当某个节点触发 429 (Too Many Requests) 时，
+        将自动切换到下一个节点，并对 429 节点进行短暂冷却以避免重复命中。
+      </div>
+    </div>
+
     <div class="mtga-soft-panel space-y-3">
       <div>
         <div class="text-sm font-semibold text-slate-900">用户数据</div>

--- a/app/components/panels/SettingsPanel.vue
+++ b/app/components/panels/SettingsPanel.vue
@@ -15,6 +15,7 @@ import {
 
 const store = useMtgaStore();
 const appInfo = store.appInfo;
+const configGroups = store.configGroups;
 
 const clearConfirmOpen = ref(false);
 const clearConfirmTitle = "确认清除数据";
@@ -130,6 +131,58 @@ const failover429CooldownSeconds = computed({
   },
 });
 
+const routingGroupIds = computed({
+  get: () => store.routingGroupIds.value,
+  set: (value) => {
+    store.routingGroupIds.value = value;
+  },
+});
+
+type RoutingGroupOption = {
+  key: string;
+  label: string;
+  ids: string[];
+};
+
+const routingGroupOptions = computed<RoutingGroupOption[]>(() => {
+  const grouped = new Map<string, RoutingGroupOption>();
+  configGroups.value.forEach((group, index) => {
+    const id = (group.id || "").trim();
+    if (!id) {
+      return;
+    }
+    const name = (group.name || "").trim();
+    const key = name ? `name:${name}` : `id:${id}`;
+    const label = name || `配置组 ${index + 1}`;
+    const current = grouped.get(key);
+    if (current) {
+      current.ids.push(id);
+      return;
+    }
+    grouped.set(key, { key, label, ids: [id] });
+  });
+  return Array.from(grouped.values());
+});
+
+const selectedRoutingGroupKeys = computed({
+  get: () => {
+    const selectedIds = new Set(routingGroupIds.value);
+    return routingGroupOptions.value
+      .filter((option) => option.ids.some((id) => selectedIds.has(id)))
+      .map((option) => option.key);
+  },
+  set: (keys: string[]) => {
+    const selectedKeys = new Set(keys);
+    routingGroupIds.value = Array.from(
+      new Set(
+        routingGroupOptions.value
+          .filter((option) => selectedKeys.has(option.key))
+          .flatMap((option) => option.ids),
+      ),
+    );
+  },
+});
+
 const handleFailoverChange = async () => {
   const ok = await store.saveConfig();
   if (ok) {
@@ -137,6 +190,19 @@ const handleFailoverChange = async () => {
   } else {
     store.appendLog("保存配置失败");
   }
+};
+
+const handleRoutingGroupsChange = async () => {
+  const ok = await store.saveConfig();
+  if (ok) {
+    if (selectedRoutingGroupKeys.value.length) {
+      store.appendLog(`已设置轮询配置组数量：${selectedRoutingGroupKeys.value.length}`);
+    } else {
+      store.appendLog("轮询配置组未指定，仅使用当前激活配置");
+    }
+    return;
+  }
+  store.appendLog("保存配置失败");
 };
 
 const handleThemeSave = (value: ThemeConfig) => {
@@ -186,8 +252,30 @@ const handleThemeSave = (value: ThemeConfig) => {
           @change="handleFailoverChange"
         />
       </div>
+      <div v-if="enable429Failover" class="pl-11 space-y-2">
+        <div class="text-xs text-slate-600">轮询配置组（可多选，未选则仅使用当前激活配置）</div>
+        <div v-if="routingGroupOptions.length" class="space-y-1">
+          <label
+            v-for="option in routingGroupOptions"
+            :key="option.key"
+            class="label cursor-pointer justify-start gap-2 p-0"
+          >
+            <input
+              v-model="selectedRoutingGroupKeys"
+              type="checkbox"
+              class="checkbox checkbox-primary checkbox-xs"
+              :value="option.key"
+              @change="handleRoutingGroupsChange"
+            />
+            <span class="label-text text-xs text-slate-700">
+              {{ option.label }} · {{ option.ids.length }} 个 API
+            </span>
+          </label>
+        </div>
+        <div v-else class="text-xs text-slate-400">暂无可选配置组</div>
+      </div>
       <div class="text-xs text-slate-500 pl-11 leading-relaxed">
-        开启后，请求将在各配置组间轮询分发。若节点触发 429 (Too Many Requests)
+        开启后，请求将在选中配置组间轮询分发。若节点触发 429 (Too Many Requests)
         频率限制，将自动静默切换至可用节点并对受限节点执行冷却隔离，确保服务连续性。
       </div>
     </div>

--- a/app/components/panels/SettingsPanel.vue
+++ b/app/components/panels/SettingsPanel.vue
@@ -164,8 +164,8 @@ const handleThemeSave = (value: ThemeConfig) => {
   <div class="mt-4 space-y-4">
     <div class="mtga-soft-panel space-y-3">
       <div>
-        <div class="text-sm font-semibold text-slate-900">高级策略</div>
-        <div class="text-xs text-slate-500">API 调度与故障转移</div>
+        <div class="text-sm font-semibold text-slate-900">转发策略</div>
+        <div class="text-xs text-slate-500">负载均衡与自动容错</div>
       </div>
       <label class="label cursor-pointer justify-start gap-3 p-0">
         <input
@@ -174,21 +174,21 @@ const handleThemeSave = (value: ThemeConfig) => {
           class="toggle toggle-primary toggle-sm"
           @change="handleFailoverChange"
         />
-        <span class="label-text text-slate-700">启用 API 智能调度（轮询 + 429 切换）</span>
+        <span class="label-text text-slate-700">启用多节点轮询与自动故障转移</span>
       </label>
-      <label class="label justify-start gap-3 p-0 pl-11">
-        <span class="label-text text-slate-700">429 冷却（秒）</span>
+      <div v-if="enable429Failover" class="flex items-center gap-3 pl-11">
+        <span class="text-xs text-slate-600">节点冷却周期 (秒)</span>
         <input
           v-model.number="failover429CooldownSeconds"
           type="number"
+          class="mtga-input w-20 px-2 py-1 text-center"
           min="1"
-          class="input input-sm w-24"
           @change="handleFailoverChange"
         />
-      </label>
-      <div class="text-xs text-slate-500 pl-11">
-        开启后，请求会在配置组间轮询分发；当某个节点触发 429 (Too Many Requests) 时，
-        将自动切换到下一个节点，并对 429 节点进行短暂冷却以避免重复命中。
+      </div>
+      <div class="text-xs text-slate-500 pl-11 leading-relaxed">
+        开启后，请求将在各配置组间轮询分发。若节点触发 429 (Too Many Requests)
+        频率限制，将自动静默切换至可用节点并对受限节点执行冷却隔离，确保服务连续性。
       </div>
     </div>
 

--- a/app/composables/mtgaTypes.ts
+++ b/app/composables/mtgaTypes.ts
@@ -14,6 +14,7 @@ export type ConfigPayload = {
   mapped_model_id: string;
   mtga_auth_key: string;
   enable_429_failover?: boolean;
+  failover_429_cooldown_seconds?: number;
 };
 
 export type AppInfo = {

--- a/app/composables/mtgaTypes.ts
+++ b/app/composables/mtgaTypes.ts
@@ -1,4 +1,5 @@
 export type ConfigGroup = {
+  id?: string;
   name?: string;
   api_url: string;
   model_id: string;
@@ -13,6 +14,7 @@ export type ConfigPayload = {
   current_config_index: number;
   mapped_model_id: string;
   mtga_auth_key: string;
+  routing_group_ids?: string[];
   enable_429_failover?: boolean;
   failover_429_cooldown_seconds?: number;
 };

--- a/app/composables/mtgaTypes.ts
+++ b/app/composables/mtgaTypes.ts
@@ -13,6 +13,7 @@ export type ConfigPayload = {
   current_config_index: number;
   mapped_model_id: string;
   mtga_auth_key: string;
+  enable_429_failover?: boolean;
 };
 
 export type AppInfo = {

--- a/app/composables/useMtgaStore.ts
+++ b/app/composables/useMtgaStore.ts
@@ -166,6 +166,10 @@ export const useMtgaStore = () => {
   const mappedModelId = useState<string>("mtga-mapped-model-id", () => "");
   const mtgaAuthKey = useState<string>("mtga-auth-key", () => "");
   const enable429Failover = useState<boolean>("mtga-enable-429-failover", () => false);
+  const failover429CooldownSeconds = useState<number>(
+    "mtga-failover-429-cooldown-seconds",
+    () => 60,
+  );
   const runtimeOptions = useState<RuntimeOptions>("mtga-runtime-options", () => ({
     ...DEFAULT_RUNTIME_OPTIONS,
   }));
@@ -454,6 +458,10 @@ export const useMtgaStore = () => {
     mappedModelId.value = coerceText(result.mapped_model_id);
     mtgaAuthKey.value = coerceText(result.mtga_auth_key);
     enable429Failover.value = Boolean(result.enable_429_failover);
+    const cooldownRaw = Number(result.failover_429_cooldown_seconds);
+    failover429CooldownSeconds.value = Number.isFinite(cooldownRaw)
+      ? Math.max(1, Math.round(cooldownRaw))
+      : 60;
     return true;
   };
 
@@ -466,6 +474,10 @@ export const useMtgaStore = () => {
       mapped_model_id: coerceText(mappedModelId.value),
       mtga_auth_key: coerceText(mtgaAuthKey.value),
       enable_429_failover: enable429Failover.value,
+      failover_429_cooldown_seconds: Math.max(
+        1,
+        Math.round(Number(failover429CooldownSeconds.value) || 60),
+      ),
     };
     const ok = await api.saveConfig(payload);
     return Boolean(ok);
@@ -790,6 +802,7 @@ export const useMtgaStore = () => {
     mappedModelId,
     mtgaAuthKey,
     enable429Failover,
+    failover429CooldownSeconds,
     runtimeOptions,
     logs,
     systemPrompts,

--- a/app/composables/useMtgaStore.ts
+++ b/app/composables/useMtgaStore.ts
@@ -165,6 +165,7 @@ export const useMtgaStore = () => {
   const currentConfigIndex = useState<number>("mtga-current-config-index", () => 0);
   const mappedModelId = useState<string>("mtga-mapped-model-id", () => "");
   const mtgaAuthKey = useState<string>("mtga-auth-key", () => "");
+  const enable429Failover = useState<boolean>("mtga-enable-429-failover", () => false);
   const runtimeOptions = useState<RuntimeOptions>("mtga-runtime-options", () => ({
     ...DEFAULT_RUNTIME_OPTIONS,
   }));
@@ -452,6 +453,7 @@ export const useMtgaStore = () => {
     );
     mappedModelId.value = coerceText(result.mapped_model_id);
     mtgaAuthKey.value = coerceText(result.mtga_auth_key);
+    enable429Failover.value = Boolean(result.enable_429_failover);
     return true;
   };
 
@@ -463,6 +465,7 @@ export const useMtgaStore = () => {
       current_config_index: clampedIndex,
       mapped_model_id: coerceText(mappedModelId.value),
       mtga_auth_key: coerceText(mtgaAuthKey.value),
+      enable_429_failover: enable429Failover.value,
     };
     const ok = await api.saveConfig(payload);
     return Boolean(ok);
@@ -786,6 +789,7 @@ export const useMtgaStore = () => {
     currentConfigIndex,
     mappedModelId,
     mtgaAuthKey,
+    enable429Failover,
     runtimeOptions,
     logs,
     systemPrompts,

--- a/app/composables/useMtgaStore.ts
+++ b/app/composables/useMtgaStore.ts
@@ -162,6 +162,19 @@ const clampIndex = (value: number, max: number) => {
   return Math.min(Math.max(value, 0), max - 1);
 };
 
+const createConfigGroupId = (index: number) => {
+  if (typeof globalThis !== "undefined" && globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `group-${Date.now()}-${index}-${Math.random().toString(16).slice(2, 10)}`;
+};
+
+const normalizeConfigGroups = (groups: ConfigGroup[]) =>
+  groups.map((group, index) => {
+    const id = coerceText(group.id).trim() || createConfigGroupId(index);
+    return { ...group, id };
+  });
+
 export const useMtgaStore = () => {
   const api = useMtgaApi();
 
@@ -169,6 +182,7 @@ export const useMtgaStore = () => {
   const currentConfigIndex = useState<number>("mtga-current-config-index", () => 0);
   const mappedModelId = useState<string>("mtga-mapped-model-id", () => "");
   const mtgaAuthKey = useState<string>("mtga-auth-key", () => "");
+  const routingGroupIds = useState<string[]>("mtga-routing-group-ids", () => []);
   const enable429Failover = useState<boolean>("mtga-enable-429-failover", () => false);
   const failover429CooldownSeconds = useState<number>(
     "mtga-failover-429-cooldown-seconds",
@@ -454,11 +468,24 @@ export const useMtgaStore = () => {
     if (!result) {
       return false;
     }
-    configGroups.value = result.config_groups || [];
+    const loadedGroups = Array.isArray(result.config_groups) ? result.config_groups : [];
+    configGroups.value = normalizeConfigGroups(loadedGroups);
     currentConfigIndex.value = clampIndex(
       result.current_config_index ?? 0,
       configGroups.value.length,
     );
+    const availableGroupIds = new Set(
+      configGroups.value.map((group) => coerceText(group.id).trim()),
+    );
+    routingGroupIds.value = Array.isArray(result.routing_group_ids)
+      ? Array.from(
+          new Set(
+            result.routing_group_ids
+              .map((id) => coerceText(id).trim())
+              .filter((id) => id && availableGroupIds.has(id)),
+          ),
+        )
+      : [];
     mappedModelId.value = coerceText(result.mapped_model_id);
     mtgaAuthKey.value = coerceText(result.mtga_auth_key);
     enable429Failover.value = Boolean(result.enable_429_failover);
@@ -470,13 +497,25 @@ export const useMtgaStore = () => {
   };
 
   const saveConfig = async () => {
+    configGroups.value = normalizeConfigGroups(configGroups.value);
     const clampedIndex = clampIndex(currentConfigIndex.value, configGroups.value.length);
     currentConfigIndex.value = clampedIndex;
+    const availableGroupIds = new Set(
+      configGroups.value.map((group) => coerceText(group.id).trim()),
+    );
+    routingGroupIds.value = Array.from(
+      new Set(
+        routingGroupIds.value
+          .map((id) => coerceText(id).trim())
+          .filter((id) => id && availableGroupIds.has(id)),
+      ),
+    );
     const payload: ConfigPayload = {
       config_groups: configGroups.value,
       current_config_index: clampedIndex,
       mapped_model_id: coerceText(mappedModelId.value),
       mtga_auth_key: coerceText(mtgaAuthKey.value),
+      routing_group_ids: routingGroupIds.value,
       enable_429_failover: enable429Failover.value,
       failover_429_cooldown_seconds: Math.max(
         1,
@@ -822,6 +861,7 @@ export const useMtgaStore = () => {
     currentConfigIndex,
     mappedModelId,
     mtgaAuthKey,
+    routingGroupIds,
     enable429Failover,
     failover429CooldownSeconds,
     runtimeOptions,

--- a/app/docs/ui-migration.md
+++ b/app/docs/ui-migration.md
@@ -56,6 +56,8 @@ app/
 - [x] `MainTabs` 支持切换并挂载各 Tab 内容（证书/hosts/代理/数据/关于）。
 - [x] `ConfigGroupPanel` 改为可交互：列表数据、选中状态、增删改弹窗。
 - [x] `GlobalConfigPanel` 与 `RuntimeOptionsPanel` 接入真实数据与保存逻辑。
+- [x] 新增 `routing_group_ids` 配置读写，支持按组路由选择。
+- [x] 设置页接入配置组多选，轮询仅针对选中组（空则回退全部）。
 - [x] `LogPanel` 支持追加日志流（从后端或前端事件）。
 - [x] `UpdateDialog`、确认弹窗完善交互与 HTML 内容渲染。
 - [x] 用 `pyInvoke` 串起最小功能链路（例如 `greet` -> 日志输出）。
@@ -146,6 +148,7 @@ config_groups: ConfigGroup[]
 current_config_index: number
 mapped_model_id: string
 mtga_auth_key: string
+routing_group_ids: string[]
 runtime_options: {
   debugMode: boolean
   disableSslStrict: boolean

--- a/python-src/modules/proxy/proxy_app.py
+++ b/python-src/modules/proxy/proxy_app.py
@@ -462,7 +462,6 @@ class ProxyApp:
         inbound_route = str(snapshot["inbound_route"])
         target_model_id = str(snapshot["target_model_id"])
         target_api_base_url = str(snapshot["target_api_base_url"])
-        middle_route = str(snapshot["middle_route"])
         stream_mode = snapshot["stream_mode"]
         debug_mode = bool(snapshot["debug_mode"])
         auth = snapshot["auth"]
@@ -525,12 +524,10 @@ class ProxyApp:
         client_requested_stream = request_data.get("stream", False)
         log(f"客户端请求的流模式: {client_requested_stream}")
 
-        if "model" in request_data:
-            original_model = request_data["model"]
-            log(f"替换模型名: {original_model} -> {target_model_id}")
-            request_data["model"] = target_model_id
-        else:
-            log(f"请求中没有 model 字段，添加 model: {target_model_id}")
+        # 记录客户端原始请求的模型名，用于后续日志展示
+        original_model = request_data.get("model", "unknown")
+
+        if "model" not in request_data:
             request_data["model"] = target_model_id
 
         if stream_mode is not None:
@@ -572,10 +569,7 @@ class ProxyApp:
                 and bool(proxy_config.enable_429_failover)
                 and len(api_endpoints) > 1
             )
-            if enable_routing:
-                start_index = (endpoint_cursor + 1) % len(api_endpoints)
-            else:
-                start_index = endpoint_cursor % len(api_endpoints)
+            start_index = endpoint_cursor % len(api_endpoints)
 
             response_from_target = None
             endpoint_order = [
@@ -583,7 +577,10 @@ class ProxyApp:
             ]
 
             def endpoint_key(endpoint: ProxyApiEndpoint) -> str:
-                return f"{endpoint.api_url}|{endpoint.api_key}|{endpoint.target_model_id}"
+                return (
+                    f"{endpoint.api_url}|{endpoint.api_key}|"
+                    f"{endpoint.target_model_id}|{endpoint.middle_route}"
+                )
 
             def cooldown_remaining_seconds(key: str) -> float:
                 now = time.monotonic()
@@ -620,16 +617,23 @@ class ProxyApp:
 
             for attempt, endpoint_index in enumerate(endpoint_order):
                 endpoint = api_endpoints[endpoint_index]
+                next_cursor = (endpoint_index + 1) % len(api_endpoints)
                 target_url = (
                     f"{endpoint.api_url.rstrip('/')}"
-                    f"{self._build_route(middle_route, 'chat/completions')}"
+                    f"{self._build_route(endpoint.middle_route, 'chat/completions')}"
                 )
 
                 if endpoint.target_model_id:
+                    log(f"替换模型名: {original_model} -> {endpoint.target_model_id}")
                     request_data["model"] = endpoint.target_model_id
+                else:
+                    # 如果端点没有指定特定模型，使用默认目标模型
+                    log(f"替换模型名: {original_model} -> {target_model_id}")
+                    request_data["model"] = target_model_id
 
                 current_request_data = dict(request_data)
 
+                # 仅作兼容，后续移除
                 if "siliconflow.cn" in target_url or "siliconflow.com" in target_url:
                     thinking_obj = current_request_data.get("thinking")
                     if thinking_obj is not None:
@@ -659,13 +663,24 @@ class ProxyApp:
                     log_func=log,
                 )
 
-                response_from_target = http_client.post(
-                    target_url,
-                    json=current_request_data,
-                    headers=forward_headers,
-                    stream=is_stream,
-                    timeout=300,
-                )
+                try:
+                    response_from_target = http_client.post(
+                        target_url,
+                        json=current_request_data,
+                        headers=forward_headers,
+                        stream=is_stream,
+                        timeout=300,
+                    )
+                except requests.exceptions.RequestException as request_exc:
+                    log(f"上游请求异常: {request_exc}")
+                    if enable_routing:
+                        self._set_endpoint_cursor(next_cursor)
+                    if enable_routing and attempt < len(endpoint_order) - 1:
+                        log(
+                            f"切换到下一个节点 {endpoint_index} -> {endpoint_order[attempt + 1]}"
+                        )
+                        continue
+                    raise
 
                 if response_from_target.status_code == HTTP_STATUS_TOO_MANY_REQUESTS:
                     retry_after_seconds: float | None = None
@@ -680,14 +695,17 @@ class ProxyApp:
                             else 60.0
                         )
                     key = endpoint_key(endpoint)
-                    with self._config_lock:
-                        self._endpoint_429_until[key] = time.monotonic() + retry_after_seconds
+                    if enable_routing:
+                        with self._config_lock:
+                            self._endpoint_429_until[key] = (
+                                time.monotonic() + retry_after_seconds
+                            )
                     log(
                         "上游触发 429"
                         f"（节点={endpoint_index}，总节点={len(api_endpoints)}，retry-after={retry_after_text}）"
                     )
                     if enable_routing:
-                        self._set_endpoint_cursor(endpoint_index)
+                        self._set_endpoint_cursor(next_cursor)
                     if enable_routing and attempt < len(endpoint_order) - 1:
                         log(f"切换到下一个节点 {endpoint_index} -> {endpoint_order[attempt + 1]}")
                         with contextlib.suppress(Exception):
@@ -695,8 +713,34 @@ class ProxyApp:
                         response_from_target = None
                         continue
 
+                failover_status_codes = {400, 401, 403, 404, 408, 500, 502, 503, 504}
+                if (
+                    enable_routing
+                    and response_from_target.status_code in failover_status_codes
+                    and attempt < len(endpoint_order) - 1
+                ):
+                    raw_error_text = response_from_target.text
+                    log(
+                        "上游原始错误响应: "
+                        f"status={response_from_target.status_code}, body={raw_error_text}"
+                    )
+                    self._set_endpoint_cursor(next_cursor)
+                    log(
+                        f"上游返回错误状态码: {response_from_target.status_code}，尝试切换节点"
+                    )
+                    log(
+                        f"切换到下一个节点 {endpoint_index} -> {endpoint_order[attempt + 1]}"
+                    )
+                    with contextlib.suppress(Exception):
+                        response_from_target.close()
+                    response_from_target = None
+                    continue
+
                 response_from_target.raise_for_status()
-                self._set_endpoint_cursor(endpoint_index)
+                # 只有请求成功才更新 cursor，确保下一次请求从下一个节点开始
+                if enable_routing:
+                    self._set_endpoint_cursor(next_cursor)
+
                 with self._config_lock:
                     self._endpoint_429_until.pop(endpoint_key(endpoint), None)
                 if debug_mode:

--- a/python-src/modules/proxy/proxy_app.py
+++ b/python-src/modules/proxy/proxy_app.py
@@ -26,6 +26,7 @@ from modules.runtime.resource_manager import ResourceManager
 from modules.services.system_prompt_service import SystemPromptStore
 
 HTTP_STATUS_TOO_MANY_REQUESTS = 429
+HTTP_STATUS_BAD_REQUEST = 400
 
 
 class ProxyApp:
@@ -594,7 +595,7 @@ class ProxyApp:
                     return until - now
 
             if enable_routing:
-                available = []
+                available: list[int] = []
                 for idx in endpoint_order:
                     remaining = cooldown_remaining_seconds(endpoint_key(api_endpoints[idx]))
                     if remaining <= 0:
@@ -634,10 +635,10 @@ class ProxyApp:
                     if thinking_obj is not None:
                         log(f"适配 SiliconFlow 参数，thinking={json.dumps(thinking_obj)}")
                         if isinstance(thinking_obj, dict):
-                            t_type = thinking_obj.get("type")
-                            t_budget = (
-                                thinking_obj.get("budget_tokens")
-                                or thinking_obj.get("budget")
+                            thinking_map = cast(dict[str, Any], thinking_obj)
+                            t_type = thinking_map.get("type")
+                            t_budget = thinking_map.get("budget_tokens") or thinking_map.get(
+                                "budget"
                             )
                             if isinstance(t_type, str) and t_type:
                                 current_request_data["enable_thinking"] = t_type != "disabled"
@@ -673,7 +674,11 @@ class ProxyApp:
                     if retry_after and retry_after.isdigit():
                         retry_after_seconds = float(int(retry_after))
                     if retry_after_seconds is None:
-                        retry_after_seconds = 10.0
+                        retry_after_seconds = (
+                            float(proxy_config.failover_429_cooldown_seconds)
+                            if isinstance(proxy_config, ProxyConfig)
+                            else 60.0
+                        )
                     key = endpoint_key(endpoint)
                     with self._config_lock:
                         self._endpoint_429_until[key] = time.monotonic() + retry_after_seconds
@@ -887,9 +892,10 @@ class ProxyApp:
         except requests.exceptions.HTTPError as e:
             error_msg = f"目标 API HTTP 错误: {e.response.status_code} - {e.response.text}"
             log(error_msg)
-            if e.response.status_code == 400:
+            if e.response.status_code == HTTP_STATUS_BAD_REQUEST:
                 with contextlib.suppress(Exception):
-                    log(f"--- 触发 400 错误的请求参数 ---\\n{json.dumps(request_data, indent=2, ensure_ascii=False)}")
+                    request_dump = json.dumps(request_data, indent=2, ensure_ascii=False)
+                    log(f"--- 触发 400 错误的请求参数 ---\\n{request_dump}")
             with contextlib.suppress(Exception):
                 if e.response is not None:
                     e.response.close()

--- a/python-src/modules/proxy/proxy_app.py
+++ b/python-src/modules/proxy/proxy_app.py
@@ -587,17 +587,21 @@ class ProxyApp:
                     timeout=300,
                 )
 
-                if (
-                    response_from_target.status_code == HTTP_STATUS_TOO_MANY_REQUESTS
-                    and attempt < len(api_endpoints) - 1
-                ):
-                    next_index = (endpoint_index + 1) % len(api_endpoints)
-                    log(f"上游触发 429，切换节点 {endpoint_index} -> {next_index}")
-                    self._set_endpoint_cursor(next_index)
-                    with contextlib.suppress(Exception):
-                        response_from_target.close()
-                    response_from_target = None
-                    continue
+                if response_from_target.status_code == HTTP_STATUS_TOO_MANY_REQUESTS:
+                    retry_after = response_from_target.headers.get("retry-after")
+                    retry_after_text = retry_after if retry_after else "-"
+                    log(
+                        "上游触发 429"
+                        f"（节点={endpoint_index}，总节点={len(api_endpoints)}，retry-after={retry_after_text}）"
+                    )
+                    if attempt < len(api_endpoints) - 1:
+                        next_index = (endpoint_index + 1) % len(api_endpoints)
+                        log(f"切换到下一个节点 {endpoint_index} -> {next_index}")
+                        self._set_endpoint_cursor(next_index)
+                        with contextlib.suppress(Exception):
+                            response_from_target.close()
+                        response_from_target = None
+                        continue
 
                 response_from_target.raise_for_status()
                 self._set_endpoint_cursor(endpoint_index)

--- a/python-src/modules/proxy/proxy_app.py
+++ b/python-src/modules/proxy/proxy_app.py
@@ -47,6 +47,7 @@ class ProxyApp:
         self._root_logger_default_level = logging.getLogger().level
         self._app_logger_default_level = logging.WARNING
         self._endpoint_cursor = 0
+        self._endpoint_429_until: dict[str, float] = {}
         self.app: Flask | None = None
         self.valid = True
         self.proxy_config: ProxyConfig | None = None
@@ -557,17 +558,95 @@ class ProxyApp:
             if isinstance(proxy_config, ProxyConfig):
                 api_endpoints = proxy_config.api_endpoints
             else:
-                api_endpoints = (ProxyApiEndpoint(api_url=target_api_base_url, api_key=""),)
+                api_endpoints = (
+                    ProxyApiEndpoint(
+                        api_url=target_api_base_url,
+                        api_key="",
+                        target_model_id=target_model_id,
+                    ),
+                )
 
-            start_index = endpoint_cursor % len(api_endpoints)
+            enable_routing = (
+                isinstance(proxy_config, ProxyConfig)
+                and bool(proxy_config.enable_429_failover)
+                and len(api_endpoints) > 1
+            )
+            if enable_routing:
+                start_index = (endpoint_cursor + 1) % len(api_endpoints)
+            else:
+                start_index = endpoint_cursor % len(api_endpoints)
+
             response_from_target = None
-            for attempt in range(len(api_endpoints)):
-                endpoint_index = (start_index + attempt) % len(api_endpoints)
+            endpoint_order = [
+                (start_index + offset) % len(api_endpoints) for offset in range(len(api_endpoints))
+            ]
+
+            def endpoint_key(endpoint: ProxyApiEndpoint) -> str:
+                return f"{endpoint.api_url}|{endpoint.api_key}|{endpoint.target_model_id}"
+
+            def cooldown_remaining_seconds(key: str) -> float:
+                now = time.monotonic()
+                with self._config_lock:
+                    until = float(self._endpoint_429_until.get(key, 0.0))
+                    if until <= now:
+                        self._endpoint_429_until.pop(key, None)
+                        return 0.0
+                    return until - now
+
+            if enable_routing:
+                available = []
+                for idx in endpoint_order:
+                    remaining = cooldown_remaining_seconds(endpoint_key(api_endpoints[idx]))
+                    if remaining <= 0:
+                        available.append(idx)
+                if available:
+                    endpoint_order = available
+                else:
+                    min_idx = endpoint_order[0]
+                    min_remaining = cooldown_remaining_seconds(
+                        endpoint_key(api_endpoints[min_idx])
+                    )
+                    for idx in endpoint_order[1:]:
+                        remaining = cooldown_remaining_seconds(endpoint_key(api_endpoints[idx]))
+                        if remaining < min_remaining:
+                            min_idx = idx
+                            min_remaining = remaining
+                    endpoint_order = [min_idx]
+                    log(
+                        "所有节点处于 429 冷却中"
+                        f"（节点={min_idx}，剩余={min_remaining:.1f}s）"
+                    )
+
+            for attempt, endpoint_index in enumerate(endpoint_order):
                 endpoint = api_endpoints[endpoint_index]
                 target_url = (
                     f"{endpoint.api_url.rstrip('/')}"
                     f"{self._build_route(middle_route, 'chat/completions')}"
                 )
+
+                if endpoint.target_model_id:
+                    request_data["model"] = endpoint.target_model_id
+
+                current_request_data = dict(request_data)
+
+                if "siliconflow.cn" in target_url or "siliconflow.com" in target_url:
+                    thinking_obj = current_request_data.get("thinking")
+                    if thinking_obj is not None:
+                        log(f"适配 SiliconFlow 参数，thinking={json.dumps(thinking_obj)}")
+                        if isinstance(thinking_obj, dict):
+                            t_type = thinking_obj.get("type")
+                            t_budget = (
+                                thinking_obj.get("budget_tokens")
+                                or thinking_obj.get("budget")
+                            )
+                            if isinstance(t_type, str) and t_type:
+                                current_request_data["enable_thinking"] = t_type != "disabled"
+                            if isinstance(t_budget, (int, float)):
+                                current_request_data["thinking_budget"] = int(t_budget)
+                        elif isinstance(thinking_obj, str):
+                            current_request_data["enable_thinking"] = thinking_obj != "disabled"
+                        current_request_data.pop("thinking", None)
+
                 log(f"转发请求到: {target_url}")
 
                 target_api_key = endpoint.api_key
@@ -581,23 +660,31 @@ class ProxyApp:
 
                 response_from_target = http_client.post(
                     target_url,
-                    json=request_data,
+                    json=current_request_data,
                     headers=forward_headers,
                     stream=is_stream,
                     timeout=300,
                 )
 
                 if response_from_target.status_code == HTTP_STATUS_TOO_MANY_REQUESTS:
+                    retry_after_seconds: float | None = None
                     retry_after = response_from_target.headers.get("retry-after")
                     retry_after_text = retry_after if retry_after else "-"
+                    if retry_after and retry_after.isdigit():
+                        retry_after_seconds = float(int(retry_after))
+                    if retry_after_seconds is None:
+                        retry_after_seconds = 10.0
+                    key = endpoint_key(endpoint)
+                    with self._config_lock:
+                        self._endpoint_429_until[key] = time.monotonic() + retry_after_seconds
                     log(
                         "上游触发 429"
                         f"（节点={endpoint_index}，总节点={len(api_endpoints)}，retry-after={retry_after_text}）"
                     )
-                    if attempt < len(api_endpoints) - 1:
-                        next_index = (endpoint_index + 1) % len(api_endpoints)
-                        log(f"切换到下一个节点 {endpoint_index} -> {next_index}")
-                        self._set_endpoint_cursor(next_index)
+                    if enable_routing:
+                        self._set_endpoint_cursor(endpoint_index)
+                    if enable_routing and attempt < len(endpoint_order) - 1:
+                        log(f"切换到下一个节点 {endpoint_index} -> {endpoint_order[attempt + 1]}")
                         with contextlib.suppress(Exception):
                             response_from_target.close()
                         response_from_target = None
@@ -605,6 +692,8 @@ class ProxyApp:
 
                 response_from_target.raise_for_status()
                 self._set_endpoint_cursor(endpoint_index)
+                with self._config_lock:
+                    self._endpoint_429_until.pop(endpoint_key(endpoint), None)
                 if debug_mode:
                     log(f"上游响应状态码: {response_from_target.status_code}")
                     log(f"上游 Content-Type: {response_from_target.headers.get('content-type')}")
@@ -798,6 +887,9 @@ class ProxyApp:
         except requests.exceptions.HTTPError as e:
             error_msg = f"目标 API HTTP 错误: {e.response.status_code} - {e.response.text}"
             log(error_msg)
+            if e.response.status_code == 400:
+                with contextlib.suppress(Exception):
+                    log(f"--- 触发 400 错误的请求参数 ---\\n{json.dumps(request_data, indent=2, ensure_ascii=False)}")
             with contextlib.suppress(Exception):
                 if e.response is not None:
                     e.response.close()

--- a/python-src/modules/proxy/proxy_app.py
+++ b/python-src/modules/proxy/proxy_app.py
@@ -13,12 +13,19 @@ import requests
 from flask import Flask, Response, jsonify, request
 
 from modules.proxy.proxy_auth import ProxyAuth
-from modules.proxy.proxy_config import DEFAULT_MIDDLE_ROUTE, ProxyConfig, build_proxy_config
+from modules.proxy.proxy_config import (
+    DEFAULT_MIDDLE_ROUTE,
+    ProxyApiEndpoint,
+    ProxyConfig,
+    build_proxy_config,
+)
 from modules.proxy.proxy_transport import ProxyTransport
 from modules.runtime.error_codes import ErrorCode
 from modules.runtime.operation_result import OperationResult
 from modules.runtime.resource_manager import ResourceManager
 from modules.services.system_prompt_service import SystemPromptStore
+
+HTTP_STATUS_TOO_MANY_REQUESTS = 429
 
 
 class ProxyApp:
@@ -39,6 +46,7 @@ class ProxyApp:
         self._transport_ref_counts: dict[int, int] = {}
         self._root_logger_default_level = logging.getLogger().level
         self._app_logger_default_level = logging.WARNING
+        self._endpoint_cursor = 0
         self.app: Flask | None = None
         self.valid = True
         self.proxy_config: ProxyConfig | None = None
@@ -111,6 +119,7 @@ class ProxyApp:
                 "transport": self.transport,
                 "http_client": self.http_client,
                 "proxy_config": self.proxy_config,
+                "endpoint_cursor": self._endpoint_cursor,
             }
 
     def _snapshot_chat_runtime_state(self) -> dict[str, Any]:
@@ -133,6 +142,7 @@ class ProxyApp:
                 "transport": transport,
                 "http_client": self.http_client,
                 "proxy_config": self.proxy_config,
+                "endpoint_cursor": self._endpoint_cursor,
             }
 
     def _release_transport_ref(self, transport: ProxyTransport | None) -> None:
@@ -210,6 +220,7 @@ class ProxyApp:
             self.auth = new_auth
             self.transport = new_transport
             self.http_client = new_transport.session
+            self._endpoint_cursor = 0
 
         self._apply_debug_logging(self.debug_mode)
 
@@ -226,6 +237,10 @@ class ProxyApp:
         base = time.strftime("%H:%M:%S", time.localtime(now))
         ms = int((now % 1) * 1000)
         return f"{base}.{ms:03d}"
+
+    def _set_endpoint_cursor(self, value: int) -> None:
+        with self._config_lock:
+            self._endpoint_cursor = value
 
     def _log_request(self, request_id: str, message: str) -> None:
         self.log_func(f"{self._timestamp_ms()} [{request_id}] {message}")
@@ -452,6 +467,7 @@ class ProxyApp:
         transport = snapshot["transport"]
         http_client = snapshot["http_client"]
         proxy_config = snapshot["proxy_config"]
+        endpoint_cursor = int(snapshot["endpoint_cursor"] or 0)
         transport_released = False
 
         def release_transport() -> None:
@@ -533,36 +549,65 @@ class ProxyApp:
                 {"error": {"message": "Invalid authentication", "type": "authentication_error"}}
             ), 401
 
-        target_api_key = ""
-        if isinstance(proxy_config, ProxyConfig):
-            target_api_key = proxy_config.api_key
-        forward_headers = auth.build_forward_headers(
-            auth_header,
-            target_api_key,
-            log_func=log,
-        )
-
         try:
-            target_url = (
-                f"{target_api_base_url.rstrip('/')}"
-                f"{self._build_route(middle_route, 'chat/completions')}"
-            )
-            log(f"转发请求到: {target_url}")
-
             is_stream = request_data.get("stream", False)
             log(f"流模式: {is_stream}")
 
-            response_from_target = http_client.post(
-                target_url,
-                json=request_data,
-                headers=forward_headers,
-                stream=is_stream,
-                timeout=300,
-            )
-            response_from_target.raise_for_status()
-            if debug_mode:
-                log(f"上游响应状态码: {response_from_target.status_code}")
-                log(f"上游 Content-Type: {response_from_target.headers.get('content-type')}")
+            api_endpoints: tuple[ProxyApiEndpoint, ...]
+            if isinstance(proxy_config, ProxyConfig):
+                api_endpoints = proxy_config.api_endpoints
+            else:
+                api_endpoints = (ProxyApiEndpoint(api_url=target_api_base_url, api_key=""),)
+
+            start_index = endpoint_cursor % len(api_endpoints)
+            response_from_target = None
+            for attempt in range(len(api_endpoints)):
+                endpoint_index = (start_index + attempt) % len(api_endpoints)
+                endpoint = api_endpoints[endpoint_index]
+                target_url = (
+                    f"{endpoint.api_url.rstrip('/')}"
+                    f"{self._build_route(middle_route, 'chat/completions')}"
+                )
+                log(f"转发请求到: {target_url}")
+
+                target_api_key = endpoint.api_key
+                if not target_api_key and isinstance(proxy_config, ProxyConfig):
+                    target_api_key = proxy_config.api_key
+                forward_headers = auth.build_forward_headers(
+                    auth_header,
+                    target_api_key,
+                    log_func=log,
+                )
+
+                response_from_target = http_client.post(
+                    target_url,
+                    json=request_data,
+                    headers=forward_headers,
+                    stream=is_stream,
+                    timeout=300,
+                )
+
+                if (
+                    response_from_target.status_code == HTTP_STATUS_TOO_MANY_REQUESTS
+                    and attempt < len(api_endpoints) - 1
+                ):
+                    next_index = (endpoint_index + 1) % len(api_endpoints)
+                    log(f"上游触发 429，切换节点 {endpoint_index} -> {next_index}")
+                    self._set_endpoint_cursor(next_index)
+                    with contextlib.suppress(Exception):
+                        response_from_target.close()
+                    response_from_target = None
+                    continue
+
+                response_from_target.raise_for_status()
+                self._set_endpoint_cursor(endpoint_index)
+                if debug_mode:
+                    log(f"上游响应状态码: {response_from_target.status_code}")
+                    log(f"上游 Content-Type: {response_from_target.headers.get('content-type')}")
+                break
+
+            if response_from_target is None:
+                raise requests.exceptions.RequestException("No available target API endpoint")
 
             if is_stream:
                 log("返回流式响应")
@@ -749,6 +794,9 @@ class ProxyApp:
         except requests.exceptions.HTTPError as e:
             error_msg = f"目标 API HTTP 错误: {e.response.status_code} - {e.response.text}"
             log(error_msg)
+            with contextlib.suppress(Exception):
+                if e.response is not None:
+                    e.response.close()
             release_transport()
             return jsonify(
                 {"error": f"Target API error: {e.response.status_code}", "details": e.response.text}

--- a/python-src/modules/proxy/proxy_config.py
+++ b/python-src/modules/proxy/proxy_config.py
@@ -34,6 +34,7 @@ class ProxyConfig:
     api_key: str
     mtga_auth_key: str
     enable_429_failover: bool
+    failover_429_cooldown_seconds: int
 
 
 def load_global_config(
@@ -182,6 +183,9 @@ def build_proxy_config(
         api_key=api_endpoints[0].api_key,
         mtga_auth_key=(global_config.get("mtga_auth_key") or ""),
         enable_429_failover=bool(global_config.get("enable_429_failover", False)),
+        failover_429_cooldown_seconds=max(
+            1, int(global_config.get("failover_429_cooldown_seconds", 60) or 60)
+        ),
     )
 
 

--- a/python-src/modules/proxy/proxy_config.py
+++ b/python-src/modules/proxy/proxy_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -15,8 +15,15 @@ type LogFunc = Callable[[str], None]
 
 
 @dataclass(frozen=True)
+class ProxyApiEndpoint:
+    api_url: str
+    api_key: str
+
+
+@dataclass(frozen=True)
 class ProxyConfig:
     target_api_base_url: str
+    api_endpoints: tuple[ProxyApiEndpoint, ...]
     middle_route: str
     custom_model_id: str
     target_model_id: str
@@ -53,6 +60,43 @@ def _resolve_target_model_id(*, raw_config: dict[str, Any], custom_model_id: str
     return target_model_id if target_model_id else custom_model_id
 
 
+def _parse_api_endpoints(*, raw_config: dict[str, Any]) -> tuple[ProxyApiEndpoint, ...]:
+    raw_list = raw_config.get("api_endpoints")
+    if isinstance(raw_list, list):
+        raw_items = cast(list[Any], raw_list)
+        endpoints: list[ProxyApiEndpoint] = []
+        for item_any in raw_items:
+            if not isinstance(item_any, dict):
+                continue
+            item = cast(dict[str, Any], item_any)
+            url_value = item.get("api_url") or item.get("url") or ""
+            if not isinstance(url_value, str):
+                url_value = ""
+            api_url = url_value.strip()
+            if not api_url:
+                continue
+            key_value = item.get("api_key") or item.get("key") or ""
+            if not isinstance(key_value, str):
+                key_value = ""
+            api_key = key_value.strip()
+            endpoints.append(ProxyApiEndpoint(api_url=api_url, api_key=api_key))
+        if endpoints:
+            return tuple(endpoints)
+
+    api_url_value = raw_config.get("api_url", PLACEHOLDER_API_URL)
+    if not isinstance(api_url_value, str):
+        api_url_value = PLACEHOLDER_API_URL
+    api_key_value = raw_config.get("api_key") or ""
+    if not isinstance(api_key_value, str):
+        api_key_value = ""
+    return (
+        ProxyApiEndpoint(
+            api_url=api_url_value,
+            api_key=api_key_value,
+        ),
+    )
+
+
 def normalize_middle_route(value: str | None) -> str:
     raw_value = (value or "").strip()
     if not raw_value:
@@ -75,7 +119,8 @@ def build_proxy_config(
     raw_config = raw_config or {}
     global_config = load_global_config(resource_manager=resource_manager, log_func=log_func)
 
-    target_api_base_url = raw_config.get("api_url", PLACEHOLDER_API_URL)
+    api_endpoints = _parse_api_endpoints(raw_config=raw_config)
+    target_api_base_url = api_endpoints[0].api_url
     if target_api_base_url == PLACEHOLDER_API_URL:
         log_func("错误: 请在配置中设置正确的 API URL")
         return None
@@ -92,19 +137,21 @@ def build_proxy_config(
 
     return ProxyConfig(
         target_api_base_url=target_api_base_url,
+        api_endpoints=api_endpoints,
         middle_route=middle_route,
         custom_model_id=custom_model_id,
         target_model_id=target_model_id,
         stream_mode=raw_config.get("stream_mode"),
         debug_mode=bool(raw_config.get("debug_mode", False)),
         disable_ssl_strict_mode=bool(raw_config.get("disable_ssl_strict_mode", False)),
-        api_key=(raw_config.get("api_key") or ""),
+        api_key=api_endpoints[0].api_key,
         mtga_auth_key=(global_config.get("mtga_auth_key") or ""),
     )
 
 
 __all__ = [
     "DEFAULT_MIDDLE_ROUTE",
+    "ProxyApiEndpoint",
     "ProxyConfig",
     "PLACEHOLDER_API_URL",
     "build_proxy_config",

--- a/python-src/modules/proxy/proxy_config.py
+++ b/python-src/modules/proxy/proxy_config.py
@@ -18,6 +18,7 @@ type LogFunc = Callable[[str], None]
 class ProxyApiEndpoint:
     api_url: str
     api_key: str
+    target_model_id: str
 
 
 @dataclass(frozen=True)
@@ -32,6 +33,7 @@ class ProxyConfig:
     disable_ssl_strict_mode: bool
     api_key: str
     mtga_auth_key: str
+    enable_429_failover: bool
 
 
 def load_global_config(
@@ -60,41 +62,69 @@ def _resolve_target_model_id(*, raw_config: dict[str, Any], custom_model_id: str
     return target_model_id if target_model_id else custom_model_id
 
 
-def _parse_api_endpoints(*, raw_config: dict[str, Any]) -> tuple[ProxyApiEndpoint, ...]:
-    raw_list = raw_config.get("api_endpoints")
-    if isinstance(raw_list, list):
-        raw_items = cast(list[Any], raw_list)
-        endpoints: list[ProxyApiEndpoint] = []
-        for item_any in raw_items:
-            if not isinstance(item_any, dict):
-                continue
-            item = cast(dict[str, Any], item_any)
-            url_value = item.get("api_url") or item.get("url") or ""
-            if not isinstance(url_value, str):
-                url_value = ""
-            api_url = url_value.strip()
-            if not api_url:
-                continue
-            key_value = item.get("api_key") or item.get("key") or ""
-            if not isinstance(key_value, str):
-                key_value = ""
-            api_key = key_value.strip()
-            endpoints.append(ProxyApiEndpoint(api_url=api_url, api_key=api_key))
-        if endpoints:
-            return tuple(endpoints)
+def _parse_api_endpoints(
+    *,
+    raw_config: dict[str, Any],
+    global_config: dict[str, Any],
+    custom_model_id: str,
+) -> tuple[ProxyApiEndpoint, ...]:
+    enable_failover = bool(global_config.get("enable_429_failover", False))
+    endpoints: list[ProxyApiEndpoint] = []
 
+    # 1. Primary endpoint (from raw_config)
     api_url_value = raw_config.get("api_url", PLACEHOLDER_API_URL)
     if not isinstance(api_url_value, str):
         api_url_value = PLACEHOLDER_API_URL
     api_key_value = raw_config.get("api_key") or ""
     if not isinstance(api_key_value, str):
         api_key_value = ""
-    return (
-        ProxyApiEndpoint(
-            api_url=api_url_value,
-            api_key=api_key_value,
-        ),
+    target_model_id = (raw_config.get("model_id") or "").strip()
+    if not target_model_id:
+        target_model_id = custom_model_id
+
+    primary_endpoint = ProxyApiEndpoint(
+        api_url=api_url_value,
+        api_key=api_key_value,
+        target_model_id=target_model_id,
     )
+    endpoints.append(primary_endpoint)
+
+    # 2. Failover endpoints
+    if enable_failover:
+        raw_groups = global_config.get("config_groups")
+        if isinstance(raw_groups, list):
+            config_groups = cast(list[Any], raw_groups)
+            for group_any in config_groups:
+                if not isinstance(group_any, dict):
+                    continue
+                group = cast(dict[str, Any], group_any)
+
+                url = (group.get("api_url") or "").strip()
+                if not url or url == PLACEHOLDER_API_URL:
+                    continue
+
+                key = (group.get("api_key") or "").strip()
+                model = (group.get("model_id") or "").strip()
+                if not model:
+                    model = custom_model_id
+
+                # Deduplicate
+                if (
+                    url == api_url_value
+                    and key == api_key_value
+                    and model == target_model_id
+                ):
+                    continue
+
+                endpoints.append(
+                    ProxyApiEndpoint(
+                        api_url=url,
+                        api_key=key,
+                        target_model_id=model,
+                    )
+                )
+
+    return tuple(endpoints)
 
 
 def normalize_middle_route(value: str | None) -> str:
@@ -119,16 +149,21 @@ def build_proxy_config(
     raw_config = raw_config or {}
     global_config = load_global_config(resource_manager=resource_manager, log_func=log_func)
 
-    api_endpoints = _parse_api_endpoints(raw_config=raw_config)
+    custom_model_id = _resolve_custom_model_id(
+        global_config=global_config,
+        raw_config=raw_config,
+    )
+
+    api_endpoints = _parse_api_endpoints(
+        raw_config=raw_config,
+        global_config=global_config,
+        custom_model_id=custom_model_id,
+    )
     target_api_base_url = api_endpoints[0].api_url
     if target_api_base_url == PLACEHOLDER_API_URL:
         log_func("错误: 请在配置中设置正确的 API URL")
         return None
 
-    custom_model_id = _resolve_custom_model_id(
-        global_config=global_config,
-        raw_config=raw_config,
-    )
     target_model_id = _resolve_target_model_id(
         raw_config=raw_config,
         custom_model_id=custom_model_id,
@@ -146,6 +181,7 @@ def build_proxy_config(
         disable_ssl_strict_mode=bool(raw_config.get("disable_ssl_strict_mode", False)),
         api_key=api_endpoints[0].api_key,
         mtga_auth_key=(global_config.get("mtga_auth_key") or ""),
+        enable_429_failover=bool(global_config.get("enable_429_failover", False)),
     )
 
 

--- a/python-src/modules/proxy/proxy_config.py
+++ b/python-src/modules/proxy/proxy_config.py
@@ -19,6 +19,7 @@ class ProxyApiEndpoint:
     api_url: str
     api_key: str
     target_model_id: str
+    middle_route: str = DEFAULT_MIDDLE_ROUTE
 
 
 @dataclass(frozen=True)
@@ -82,11 +83,14 @@ def _parse_api_endpoints(
     target_model_id = (raw_config.get("model_id") or "").strip()
     if not target_model_id:
         target_model_id = custom_model_id
+    
+    primary_middle_route = normalize_middle_route(raw_config.get("middle_route"))
 
     primary_endpoint = ProxyApiEndpoint(
         api_url=api_url_value,
         api_key=api_key_value,
         target_model_id=target_model_id,
+        middle_route=primary_middle_route,
     )
     endpoints.append(primary_endpoint)
 
@@ -108,12 +112,15 @@ def _parse_api_endpoints(
                 model = (group.get("model_id") or "").strip()
                 if not model:
                     model = custom_model_id
+                
+                # 解析配置组中的 middle_route，若未配置则使用默认值
+                route = normalize_middle_route(group.get("middle_route"))
 
-                # Deduplicate
                 if (
                     url == api_url_value
                     and key == api_key_value
                     and model == target_model_id
+                    and route == primary_middle_route
                 ):
                     continue
 
@@ -122,6 +129,7 @@ def _parse_api_endpoints(
                         api_url=url,
                         api_key=key,
                         target_model_id=model,
+                        middle_route=route,
                     )
                 )
 
@@ -139,6 +147,18 @@ def normalize_middle_route(value: str | None) -> str:
         if not raw_value:
             raw_value = "/"
     return raw_value
+
+
+def _parse_cooldown_seconds(global_config: dict[str, Any]) -> int:
+    try:
+        val = global_config.get("failover_429_cooldown_seconds")
+        if isinstance(val, (int, float)):
+            return max(1, int(val))
+        if isinstance(val, str) and val.strip().isdigit():
+            return max(1, int(val))
+        return 60
+    except (ValueError, TypeError):
+        return 60
 
 
 def build_proxy_config(
@@ -183,9 +203,7 @@ def build_proxy_config(
         api_key=api_endpoints[0].api_key,
         mtga_auth_key=(global_config.get("mtga_auth_key") or ""),
         enable_429_failover=bool(global_config.get("enable_429_failover", False)),
-        failover_429_cooldown_seconds=max(
-            1, int(global_config.get("failover_429_cooldown_seconds", 60) or 60)
-        ),
+        failover_429_cooldown_seconds=_parse_cooldown_seconds(global_config),
     )
 
 

--- a/python-src/modules/proxy/proxy_config.py
+++ b/python-src/modules/proxy/proxy_config.py
@@ -64,6 +64,47 @@ def _resolve_target_model_id(*, raw_config: dict[str, Any], custom_model_id: str
     return target_model_id if target_model_id else custom_model_id
 
 
+def _parse_endpoint_from_group(
+    group: dict[str, Any], *, custom_model_id: str
+) -> ProxyApiEndpoint | None:
+    url = (group.get("api_url") or "").strip()
+    if not url or url == PLACEHOLDER_API_URL:
+        return None
+    key = (group.get("api_key") or "").strip()
+    model = (group.get("model_id") or "").strip() or custom_model_id
+    route = normalize_middle_route(group.get("middle_route"))
+    return ProxyApiEndpoint(
+        api_url=url,
+        api_key=key,
+        target_model_id=model,
+        middle_route=route,
+    )
+
+
+def _extract_config_groups(global_config: dict[str, Any]) -> list[dict[str, Any]]:
+    config_groups: list[dict[str, Any]] = []
+    raw_groups_obj = global_config.get("config_groups")
+    if not isinstance(raw_groups_obj, list):
+        return config_groups
+    for group_any in cast(list[object], raw_groups_obj):
+        if isinstance(group_any, dict):
+            config_groups.append(cast(dict[str, Any], group_any))
+    return config_groups
+
+
+def _extract_routing_group_ids(global_config: dict[str, Any]) -> list[str]:
+    routing_group_ids: list[str] = []
+    routing_group_ids_raw = global_config.get("routing_group_ids")
+    if not isinstance(routing_group_ids_raw, list):
+        return routing_group_ids
+    for item in cast(list[object], routing_group_ids_raw):
+        if isinstance(item, str):
+            value = item.strip()
+            if value:
+                routing_group_ids.append(value)
+    return routing_group_ids
+
+
 def _parse_api_endpoints(
     *,
     raw_config: dict[str, Any],
@@ -71,67 +112,45 @@ def _parse_api_endpoints(
     custom_model_id: str,
 ) -> tuple[ProxyApiEndpoint, ...]:
     enable_failover = bool(global_config.get("enable_429_failover", False))
+    config_groups = _extract_config_groups(global_config)
+    routing_group_ids = _extract_routing_group_ids(global_config)
     endpoints: list[ProxyApiEndpoint] = []
+    endpoint_signatures: set[tuple[str, str, str, str]] = set()
 
-    # 1. Primary endpoint (from raw_config)
-    api_url_value = raw_config.get("api_url", PLACEHOLDER_API_URL)
-    if not isinstance(api_url_value, str):
-        api_url_value = PLACEHOLDER_API_URL
-    api_key_value = raw_config.get("api_key") or ""
-    if not isinstance(api_key_value, str):
-        api_key_value = ""
-    target_model_id = (raw_config.get("model_id") or "").strip()
-    if not target_model_id:
-        target_model_id = custom_model_id
-    
-    primary_middle_route = normalize_middle_route(raw_config.get("middle_route"))
+    def append_unique(group: dict[str, Any]) -> None:
+        endpoint = _parse_endpoint_from_group(group, custom_model_id=custom_model_id)
+        if endpoint is None:
+            return
+        signature = (
+            endpoint.api_url,
+            endpoint.api_key,
+            endpoint.target_model_id,
+            endpoint.middle_route,
+        )
+        if signature in endpoint_signatures:
+            return
+        endpoint_signatures.add(signature)
+        endpoints.append(endpoint)
 
-    primary_endpoint = ProxyApiEndpoint(
-        api_url=api_url_value,
-        api_key=api_key_value,
-        target_model_id=target_model_id,
-        middle_route=primary_middle_route,
-    )
-    endpoints.append(primary_endpoint)
+    selected_mode = bool(enable_failover and routing_group_ids)
+    if selected_mode:
+        selected_ids = set(routing_group_ids)
+        for group in config_groups:
+            group_id = str(group.get("id") or "").strip()
+            if group_id and group_id in selected_ids:
+                append_unique(group)
 
-    # 2. Failover endpoints
-    if enable_failover:
-        raw_groups = global_config.get("config_groups")
-        if isinstance(raw_groups, list):
-            config_groups = cast(list[Any], raw_groups)
-            for group_any in config_groups:
-                if not isinstance(group_any, dict):
-                    continue
-                group = cast(dict[str, Any], group_any)
+    # 如果启用了选择模式但结果为空（例如：选中组均无效），回退到仅使用当前激活配置
+    # 这意味着如果用户开启轮询但没选任何组，就相当于没开启轮询
+    if selected_mode and not endpoints:
+        selected_mode = False
+        # 清空以便重新添加单点
+        endpoints.clear()
+        endpoint_signatures.clear()
 
-                url = (group.get("api_url") or "").strip()
-                if not url or url == PLACEHOLDER_API_URL:
-                    continue
-
-                key = (group.get("api_key") or "").strip()
-                model = (group.get("model_id") or "").strip()
-                if not model:
-                    model = custom_model_id
-                
-                # 解析配置组中的 middle_route，若未配置则使用默认值
-                route = normalize_middle_route(group.get("middle_route"))
-
-                if (
-                    url == api_url_value
-                    and key == api_key_value
-                    and model == target_model_id
-                    and route == primary_middle_route
-                ):
-                    continue
-
-                endpoints.append(
-                    ProxyApiEndpoint(
-                        api_url=url,
-                        api_key=key,
-                        target_model_id=model,
-                        middle_route=route,
-                    )
-                )
+    # 如果未启用选择模式（或回退），只添加当前激活的配置
+    if not selected_mode:
+        append_unique(raw_config)
 
     return tuple(endpoints)
 
@@ -180,6 +199,9 @@ def build_proxy_config(
         global_config=global_config,
         custom_model_id=custom_model_id,
     )
+    if not api_endpoints:
+        log_func("错误: 没有可用的 API 端点")
+        return None
     target_api_base_url = api_endpoints[0].api_url
     if target_api_base_url == PLACEHOLDER_API_URL:
         log_func("错误: 请在配置中设置正确的 API URL")

--- a/python-src/modules/proxy/proxy_transport.py
+++ b/python-src/modules/proxy/proxy_transport.py
@@ -107,11 +107,18 @@ class ProxyTransport:
                     log_file = None
             buffer += chunk
             while True:
-                sep = buffer.find(b"\n\n")
-                if sep == -1:
+                sep_lf = buffer.find(b"\n\n")
+                sep_crlf = buffer.find(b"\r\n\r\n")
+                candidates = [pos for pos in (sep_lf, sep_crlf) if pos != -1]
+                if not candidates:
                     break
-                event = buffer[:sep]
-                buffer = buffer[sep + 2 :]
+                sep = min(candidates)
+                if sep == sep_crlf:
+                    event = buffer[:sep]
+                    buffer = buffer[sep + 4 :]
+                else:
+                    event = buffer[:sep]
+                    buffer = buffer[sep + 2 :]
                 yield chunk_index, event
         if buffer.strip():
             log("警告: 上游 SSE 结束时存在未完整分隔的残留数据")

--- a/python-src/modules/services/config_service.py
+++ b/python-src/modules/services/config_service.py
@@ -24,7 +24,7 @@ class ConfigStore:
             pass
         return [], 0
 
-    def load_global_config(self) -> tuple[str, str]:
+    def load_global_config(self) -> tuple[str, str, bool]:
         try:
             if os.path.exists(self.config_file):
                 with open(self.config_file, encoding="utf-8") as f:
@@ -32,10 +32,11 @@ class ConfigStore:
                     if config:
                         mapped_model_id = config.get("mapped_model_id", "")
                         mtga_auth_key = config.get("mtga_auth_key", "")
-                        return mapped_model_id, mtga_auth_key
+                        enable_429_failover = bool(config.get("enable_429_failover", False))
+                        return mapped_model_id, mtga_auth_key, enable_429_failover
         except Exception:
             pass
-        return "", ""
+        return "", "", False
 
     def save_config_groups(
         self,
@@ -43,6 +44,7 @@ class ConfigStore:
         current_index: int = 0,
         mapped_model_id: str | None = None,
         mtga_auth_key: str | None = None,
+        enable_429_failover: bool | None = None,
     ) -> bool:
         try:
             config_data: dict[str, Any] = {}
@@ -57,6 +59,8 @@ class ConfigStore:
                 config_data["mapped_model_id"] = mapped_model_id
             if mtga_auth_key is not None:
                 config_data["mtga_auth_key"] = mtga_auth_key
+            if enable_429_failover is not None:
+                config_data["enable_429_failover"] = enable_429_failover
 
             os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
 

--- a/python-src/modules/services/config_service.py
+++ b/python-src/modules/services/config_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -24,7 +24,7 @@ class ConfigStore:
             pass
         return [], 0
 
-    def load_global_config(self) -> tuple[str, str, bool, int]:
+    def load_global_config(self) -> tuple[str, str, bool, int, list[str]]:
         try:
             if os.path.exists(self.config_file):
                 with open(self.config_file, encoding="utf-8") as f:
@@ -34,14 +34,32 @@ class ConfigStore:
                         mtga_auth_key = config.get("mtga_auth_key", "")
                         enable_429_failover = bool(config.get("enable_429_failover", False))
                         cooldown = config.get("failover_429_cooldown_seconds", 60)
+                        routing_group_ids_raw = config.get("routing_group_ids")
+                        routing_group_ids: list[str] = []
+                        if isinstance(routing_group_ids_raw, list):
+                            seen: set[str] = set()
+                            for item in cast(list[object], routing_group_ids_raw):
+                                if not isinstance(item, str):
+                                    continue
+                                group_id = item.strip()
+                                if not group_id or group_id in seen:
+                                    continue
+                                seen.add(group_id)
+                                routing_group_ids.append(group_id)
                         try:
                             cooldown_seconds = max(1, int(cooldown or 60))
                         except Exception:
                             cooldown_seconds = 60
-                        return mapped_model_id, mtga_auth_key, enable_429_failover, cooldown_seconds
+                        return (
+                            mapped_model_id,
+                            mtga_auth_key,
+                            enable_429_failover,
+                            cooldown_seconds,
+                            routing_group_ids,
+                        )
         except Exception:
             pass
-        return "", "", False, 60
+        return "", "", False, 60, []
 
     def save_config_groups(
         self,
@@ -79,6 +97,21 @@ class ConfigStore:
                     config_data["failover_429_cooldown_seconds"] = max(
                         1, int(failover_429_cooldown_seconds or 60)
                     )
+
+                routing_group_ids_raw = global_config_updates.get("routing_group_ids")
+                if routing_group_ids_raw is not None:
+                    routing_group_ids: list[str] = []
+                    seen: set[str] = set()
+                    if isinstance(routing_group_ids_raw, list):
+                        for item in cast(list[object], routing_group_ids_raw):
+                            if not isinstance(item, str):
+                                continue
+                            group_id = item.strip()
+                            if not group_id or group_id in seen:
+                                continue
+                            seen.add(group_id)
+                            routing_group_ids.append(group_id)
+                    config_data["routing_group_ids"] = routing_group_ids
 
             os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
 

--- a/python-src/modules/services/config_service.py
+++ b/python-src/modules/services/config_service.py
@@ -24,7 +24,7 @@ class ConfigStore:
             pass
         return [], 0
 
-    def load_global_config(self) -> tuple[str, str, bool]:
+    def load_global_config(self) -> tuple[str, str, bool, int]:
         try:
             if os.path.exists(self.config_file):
                 with open(self.config_file, encoding="utf-8") as f:
@@ -33,18 +33,22 @@ class ConfigStore:
                         mapped_model_id = config.get("mapped_model_id", "")
                         mtga_auth_key = config.get("mtga_auth_key", "")
                         enable_429_failover = bool(config.get("enable_429_failover", False))
-                        return mapped_model_id, mtga_auth_key, enable_429_failover
+                        cooldown = config.get("failover_429_cooldown_seconds", 60)
+                        try:
+                            cooldown_seconds = max(1, int(cooldown or 60))
+                        except Exception:
+                            cooldown_seconds = 60
+                        return mapped_model_id, mtga_auth_key, enable_429_failover, cooldown_seconds
         except Exception:
             pass
-        return "", "", False
+        return "", "", False, 60
 
     def save_config_groups(
         self,
         config_groups: list[dict[str, Any]],
         current_index: int = 0,
-        mapped_model_id: str | None = None,
-        mtga_auth_key: str | None = None,
-        enable_429_failover: bool | None = None,
+        *,
+        global_config_updates: dict[str, Any] | None = None,
     ) -> bool:
         try:
             config_data: dict[str, Any] = {}
@@ -55,12 +59,26 @@ class ConfigStore:
             config_data["config_groups"] = config_groups
             config_data["current_config_index"] = current_index
 
-            if mapped_model_id is not None:
-                config_data["mapped_model_id"] = mapped_model_id
-            if mtga_auth_key is not None:
-                config_data["mtga_auth_key"] = mtga_auth_key
-            if enable_429_failover is not None:
-                config_data["enable_429_failover"] = enable_429_failover
+            if global_config_updates:
+                mapped_model_id = global_config_updates.get("mapped_model_id")
+                if mapped_model_id is not None:
+                    config_data["mapped_model_id"] = mapped_model_id
+
+                mtga_auth_key = global_config_updates.get("mtga_auth_key")
+                if mtga_auth_key is not None:
+                    config_data["mtga_auth_key"] = mtga_auth_key
+
+                enable_429_failover = global_config_updates.get("enable_429_failover")
+                if enable_429_failover is not None:
+                    config_data["enable_429_failover"] = bool(enable_429_failover)
+
+                failover_429_cooldown_seconds = global_config_updates.get(
+                    "failover_429_cooldown_seconds"
+                )
+                if failover_429_cooldown_seconds is not None:
+                    config_data["failover_429_cooldown_seconds"] = max(
+                        1, int(failover_429_cooldown_seconds or 60)
+                    )
 
             os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
 

--- a/python-src/modules/services/proxy_orchestration.py
+++ b/python-src/modules/services/proxy_orchestration.py
@@ -35,9 +35,9 @@ class GlobalConfigCheckResult:
 
 def ensure_global_config_ready(
     *,
-    load_global_config: Callable[[], tuple[str, str, bool, int]],
+    load_global_config: Callable[[], tuple[str, str, bool, int, list[str]]],
 ) -> GlobalConfigCheckResult:
-    mapped_model_id, mtga_auth_key, _, _ = load_global_config()
+    mapped_model_id, mtga_auth_key, *_ = load_global_config()
     mapped_model_id = (mapped_model_id or "").strip()
     mtga_auth_key = (mtga_auth_key or "").strip()
 

--- a/python-src/modules/services/proxy_orchestration.py
+++ b/python-src/modules/services/proxy_orchestration.py
@@ -35,9 +35,9 @@ class GlobalConfigCheckResult:
 
 def ensure_global_config_ready(
     *,
-    load_global_config: Callable[[], tuple[str, str]],
+    load_global_config: Callable[[], tuple[str, str, bool]],
 ) -> GlobalConfigCheckResult:
-    mapped_model_id, mtga_auth_key = load_global_config()
+    mapped_model_id, mtga_auth_key, _ = load_global_config()
     mapped_model_id = (mapped_model_id or "").strip()
     mtga_auth_key = (mtga_auth_key or "").strip()
 

--- a/python-src/modules/services/proxy_orchestration.py
+++ b/python-src/modules/services/proxy_orchestration.py
@@ -35,9 +35,9 @@ class GlobalConfigCheckResult:
 
 def ensure_global_config_ready(
     *,
-    load_global_config: Callable[[], tuple[str, str, bool]],
+    load_global_config: Callable[[], tuple[str, str, bool, int]],
 ) -> GlobalConfigCheckResult:
-    mapped_model_id, mtga_auth_key, _ = load_global_config()
+    mapped_model_id, mtga_auth_key, _, _ = load_global_config()
     mapped_model_id = (mapped_model_id or "").strip()
     mtga_auth_key = (mtga_auth_key or "").strip()
 

--- a/python-src/modules/services/user_data_service.py
+++ b/python-src/modules/services/user_data_service.py
@@ -126,7 +126,7 @@ def find_latest_backup(
     if not backup_folders:
         raise NoBackupsError("未找到任何备份")
 
-    latest_backup = max(backup_folders, key=lambda x: os.path.basename(x))
+    latest_backup = max(backup_folders, key=os.path.basename)
     backup_name = os.path.basename(latest_backup)
     return LatestBackupInfo(backup_name=backup_name, backup_path=latest_backup)
 

--- a/python-src/mtga_app/__init__.py
+++ b/python-src/mtga_app/__init__.py
@@ -258,6 +258,7 @@ class SaveConfigPayload(BaseModel):
     current_config_index: int
     mapped_model_id: str | None = None
     mtga_auth_key: str | None = None
+    enable_429_failover: bool | None = None
 
 
 @lru_cache(maxsize=1)
@@ -280,12 +281,13 @@ async def greet(body: GreetPayload) -> str:
 async def load_config() -> dict[str, Any]:
     config_store = _get_config_store()
     config_groups, current_index = config_store.load_config_groups()
-    mapped_model_id, mtga_auth_key = config_store.load_global_config()
+    mapped_model_id, mtga_auth_key, enable_429_failover = config_store.load_global_config()
     return {
         "config_groups": config_groups,
         "current_config_index": current_index,
         "mapped_model_id": mapped_model_id,
         "mtga_auth_key": mtga_auth_key,
+        "enable_429_failover": enable_429_failover,
     }
 
 
@@ -297,6 +299,7 @@ async def save_config(body: SaveConfigPayload) -> bool:
         body.current_config_index,
         body.mapped_model_id,
         body.mtga_auth_key,
+        body.enable_429_failover,
     )
 
 

--- a/python-src/mtga_app/__init__.py
+++ b/python-src/mtga_app/__init__.py
@@ -259,6 +259,7 @@ class SaveConfigPayload(BaseModel):
     mapped_model_id: str | None = None
     mtga_auth_key: str | None = None
     enable_429_failover: bool | None = None
+    failover_429_cooldown_seconds: int | None = None
 
 
 @lru_cache(maxsize=1)
@@ -281,25 +282,36 @@ async def greet(body: GreetPayload) -> str:
 async def load_config() -> dict[str, Any]:
     config_store = _get_config_store()
     config_groups, current_index = config_store.load_config_groups()
-    mapped_model_id, mtga_auth_key, enable_429_failover = config_store.load_global_config()
+    mapped_model_id, mtga_auth_key, enable_429_failover, cooldown_seconds = (
+        config_store.load_global_config()
+    )
     return {
         "config_groups": config_groups,
         "current_config_index": current_index,
         "mapped_model_id": mapped_model_id,
         "mtga_auth_key": mtga_auth_key,
         "enable_429_failover": enable_429_failover,
+        "failover_429_cooldown_seconds": cooldown_seconds,
     }
 
 
 @command_registry.command()
 async def save_config(body: SaveConfigPayload) -> bool:
     config_store = _get_config_store()
+    global_updates: dict[str, Any] = {}
+    if body.mapped_model_id is not None:
+        global_updates["mapped_model_id"] = body.mapped_model_id
+    if body.mtga_auth_key is not None:
+        global_updates["mtga_auth_key"] = body.mtga_auth_key
+    if body.enable_429_failover is not None:
+        global_updates["enable_429_failover"] = body.enable_429_failover
+    if body.failover_429_cooldown_seconds is not None:
+        global_updates["failover_429_cooldown_seconds"] = body.failover_429_cooldown_seconds
+
     return config_store.save_config_groups(
         body.config_groups,
         body.current_config_index,
-        body.mapped_model_id,
-        body.mtga_auth_key,
-        body.enable_429_failover,
+        global_config_updates=global_updates if global_updates else None,
     )
 
 

--- a/python-src/mtga_app/__init__.py
+++ b/python-src/mtga_app/__init__.py
@@ -258,6 +258,7 @@ class SaveConfigPayload(BaseModel):
     current_config_index: int
     mapped_model_id: str | None = None
     mtga_auth_key: str | None = None
+    routing_group_ids: list[str] | None = None
     enable_429_failover: bool | None = None
     failover_429_cooldown_seconds: int | None = None
 
@@ -282,7 +283,7 @@ async def greet(body: GreetPayload) -> str:
 async def load_config() -> dict[str, Any]:
     config_store = _get_config_store()
     config_groups, current_index = config_store.load_config_groups()
-    mapped_model_id, mtga_auth_key, enable_429_failover, cooldown_seconds = (
+    mapped_model_id, mtga_auth_key, enable_429_failover, cooldown_seconds, routing_group_ids = (
         config_store.load_global_config()
     )
     return {
@@ -290,6 +291,7 @@ async def load_config() -> dict[str, Any]:
         "current_config_index": current_index,
         "mapped_model_id": mapped_model_id,
         "mtga_auth_key": mtga_auth_key,
+        "routing_group_ids": routing_group_ids,
         "enable_429_failover": enable_429_failover,
         "failover_429_cooldown_seconds": cooldown_seconds,
     }
@@ -303,6 +305,8 @@ async def save_config(body: SaveConfigPayload) -> bool:
         global_updates["mapped_model_id"] = body.mapped_model_id
     if body.mtga_auth_key is not None:
         global_updates["mtga_auth_key"] = body.mtga_auth_key
+    if body.routing_group_ids is not None:
+        global_updates["routing_group_ids"] = body.routing_group_ids
     if body.enable_429_failover is not None:
         global_updates["enable_429_failover"] = body.enable_429_failover
     if body.failover_429_cooldown_seconds is not None:


### PR DESCRIPTION
## 变更目的
为代理系统引入多端点轮询（Round-Robin）与 429 自动故障转移机制，旨在提升在高并发或多账号场景下的服务稳定性，避免因单一节点触发频率限制而导致服务中断。

## 使用变更与说明

### 1. 配置多 API 节点
系统现在会自动聚合所有“配置组”中已启用的 API 节点。
- **操作**：在 API 配置页面创建多个配置组（例如：配置组 A 使用 DeepSeek，配置组 B 使用 SiliconFlow）。
- **生效**：只要配置组处于启用状态，其对应的 `api_url` 和 `api_key` 就会被纳入负载均衡池。

### 2. 开启转发策略
在 **设置面板 > 应用设置** 中新增了“转发策略”配置区：
- **启用多节点轮询与自动故障转移**：
  - **关闭（默认）**：仅使用当前激活的单一配置组。
  - **开启**：请求将在所有已启用的配置组间进行轮询（Round-Robin）分发。
- **节点冷却周期 (秒)**：
  - 当某个节点返回 `429 (Too Many Requests)` 时，该节点将进入冷却状态。
  - 在冷却时间内，系统将跳过该节点并自动切换至下一个可用节点。
  - 你可以根据不同供应商的频率限制策略，自定义冷却时长（默认为 10 秒）。

### 3. 智能适配与日志
- **SiliconFlow 适配**：若检测到 SiliconFlow 节点，系统会自动适配其 `thinking` 参数，确保思维链功能正常。
- **实时反馈**：故障转移发生时，你可以在后端日志或前端状态栏查看到节点切换的提示信息。

## 影响范围
- **后端逻辑**：
  - [proxy_app.py](file:///d:/Codes/GitHub/mtga/python-src/modules/proxy/proxy_app.py)：实现多端点轮询调度及基于 429 状态码的自动切换逻辑。
  - [proxy_config.py](file:///d:/Codes/GitHub/mtga/python-src/modules/proxy/proxy_config.py)：新增 `ProxyApiEndpoint` 结构，支持从配置组加载多个 API 节点。
  - [config_service.py](file:///d:/Codes/GitHub/mtga/python-src/modules/services/config_service.py)：扩展全局配置，新增故障转移开关及自定义冷却时间字段。
- **前端 UI**：
  - [SettingsPanel.vue](file:///d:/Codes/GitHub/mtga/app/components/panels/SettingsPanel.vue)：在设置面板新增“转发策略”区域，提供故障转移开关及节点冷却时间输入控件。
- **其他适配**：兼容了 SiliconFlow 的 `thinking` 相关参数解析。

## 验证方式
1. **多节点配置**：在设置中配置多个 API 节点，确认请求能够按轮询顺序分发。
2. **故障转移测试**：模拟并测试上游返回 429 错误，确认系统能自动跳过当前节点并切换至下一可用节点。
3. **冷却机制验证**：验证触发 429 后节点进入冷却期，在设定的 `failover_429_cooldown_seconds` 时间内不被再次调度。
4. **UI 交互**：确认设置面板的开关及数值保存功能正常。

## UI 变更截图
<img width="1500" height="1000" alt="image" src="https://github.com/user-attachments/assets/917378f6-8872-4943-bcf3-02c5704afebd" />

## 修复与优化 (针对 AI 审查反馈) [日期3.13]
- **轮询健壮性**：修复了在非 429 错误（如连接失败）时游标卡死的问题，确保故障转移能覆盖更多异常场景。
- **路由兼容性**：支持每个 API 端点配置独立的 `middle_route`，适配 OpenAI、Azure 等混合部署。
- **解析安全性**：对冷却时间配置增加了类型检查和异常捕获，防止非法输入导致崩溃。